### PR TITLE
chore: simplify `bin/dev.js` and `bin/run.js`

### DIFF
--- a/bin/dev.js
+++ b/bin/dev.js
@@ -1,9 +1,5 @@
 #!/usr/bin/env -S node --loader ts-node/esm --no-warnings=ExperimentalWarning
 
-// eslint-disable-next-line node/shebang
-async function main() {
-  const {execute} = await import('@oclif/core')
-  await execute({development: true, dir: import.meta.url})
-}
+import {execute} from '@oclif/core'
 
-await main()
+await execute({development: true, dir: import.meta.url})

--- a/bin/run.js
+++ b/bin/run.js
@@ -1,8 +1,5 @@
 #!/usr/bin/env node
 
-async function main() {
-  const {execute} = await import('@oclif/core')
-  await execute({dir: import.meta.url})
-}
+import {execute} from '@oclif/core'
 
-await main()
+await execute({dir: import.meta.url})


### PR DESCRIPTION
Related: https://github.com/oclif/core/pull/942